### PR TITLE
server: Fix exception when clients visit ws port via a browser

### DIFF
--- a/libgrabsite/server.py
+++ b/libgrabsite/server.py
@@ -21,7 +21,8 @@ class GrabberServerProtocol(WebSocketServerProtocol):
 
 	def onClose(self, wasClean, code, reason):
 		print("{} disconnected".format(self.peer))
-		self.factory.clients.remove(self)
+		if self in self.factory.clients:
+			self.factory.clients.remove(self)
 
 	def broadcastToDashboards(self, obj):
 		for client in self.factory.clients:


### PR DESCRIPTION
This is just a tiny little bug, but one I ran into when testing. If you start up `gs-server` and visit the websocket port in your browser, you get back this exception:

```
tcp:127.0.0.1:43572 disconnected
Exception in callback _SelectorTransport._call_connection_lost(None)
handle: <Handle _SelectorTransport._call_connection_lost(None)>
Traceback (most recent call last):
  File "/usr/lib64/python3.4/asyncio/events.py", line 120, in _run
    self._callback(*self._args)
  File "/usr/lib64/python3.4/asyncio/selector_events.py", line 609, in _call_connection_lost
    self._protocol.connection_lost(exc)
  File "/home/dan/code/basc/grab-site/env/lib64/python3.4/site-packages/autobahn-0.11.0-py3.4.egg/autobahn/asyncio/websocket.py", line 99, in connection_lost
    self._connectionLost(exc)
  File "/home/dan/code/basc/grab-site/env/lib64/python3.4/site-packages/autobahn-0.11.0-py3.4.egg/autobahn/websocket/protocol.py", line 2428, in _connectionLost
    WebSocketProtocol._connectionLost(self, reason)
  File "/home/dan/code/basc/grab-site/env/lib64/python3.4/site-packages/autobahn-0.11.0-py3.4.egg/autobahn/websocket/protocol.py", line 1114, in _connectionLost
    self._onClose(self.wasClean, WebSocketProtocol.CLOSE_STATUS_CODE_ABNORMAL_CLOSE, "connection was closed uncleanly (%s)" % self.wasNotCleanReason)
  File "/home/dan/code/basc/grab-site/env/lib64/python3.4/site-packages/autobahn-0.11.0-py3.4.egg/autobahn/asyncio/websocket.py", line 176, in _onClose
    res = self.onClose(wasClean, code, reason)
  File "/home/dan/code/basc/grab-site/libgrabsite/server.py", line 24, in onClose
    self.factory.clients.remove(self)
KeyError: <libgrabsite.server.GrabberServerProtocol object at 0x7f957bc27ef0>
```

This just fixes that exception.