### PR TITLE
Simplify development setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,121 @@
-__pycache__
+
+# Created by https://www.gitignore.io/api/windows,osx,linux,python
+
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/grab-site
+++ b/grab-site
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from libgrabsite import main
 main.main()

--- a/gs-dump-urls
+++ b/gs-dump-urls
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from libgrabsite import dump_urls
 dump_urls.main()

--- a/gs-server
+++ b/gs-server
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from libgrabsite import server
 server.main()

--- a/libgrabsite/dupespotter.py
+++ b/libgrabsite/dupespotter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 try:
 	from setuptools import setup


### PR DESCRIPTION
These are just a few small changes to cater to dev environments, and make things a bit easier for those using virtualenvs and running into issues.

The changes to use `env python3` instead of just `python3` are because doing it the `env` way makes sure the right Python binary is selected when using virtualenvs (which are very useful for development environments), as well as just being the recommended way to launch shell scripts. This makes sure the right `python3` binary currently in the path is selected, rather than always the one living at `/usr/bin/python3`.

The `.gitignore` changes extend it to ignore OS-specific files, Windows/OSX/Linux, as well as more Python files. This includes the specific directories used for virtualenvs and other Python stuff that should be ignored by git.

I use `gitignore.io` to generate most of my gitignore files, so I do like leaving their little tagline up the top. But I can just as easily get rid of it, just let me know.