### PR TITLE
Make gs-server require a single port only

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,18 +396,13 @@ Advanced `gs-server` options
 ---
 These environmental variables control what `gs-server` listens on:
 
-*	`GRAB_SITE_HTTP_INTERFACE` (default 0.0.0.0)
-*	`GRAB_SITE_HTTP_PORT` (default 29000)
-*	`GRAB_SITE_WS_INTERFACE` (default 0.0.0.0)
-*	`GRAB_SITE_WS_PORT` (default 29001)
-
-`GRAB_SITE_WS_PORT` should be 1 port higher than `GRAB_SITE_HTTP_PORT`,
-or else you will have to add `?host=WS_HOST:WS_PORT` to your dashboard URL.
+*	`GRAB_SITE_INTERFACE` (default 0.0.0.0)
+*	`GRAB_SITE_PORT` (default 29000)
 
 These environmental variables control which server each `grab-site` process connects to:
 
-*	`GRAB_SITE_WS_HOST` (default 127.0.0.1)
-*	`GRAB_SITE_WS_PORT` (default 29001)
+*	`GRAB_SITE_HOST` (default 127.0.0.1)
+*	`GRAB_SITE_PORT` (default 29000)
 
 
 

--- a/libgrabsite/404.html
+++ b/libgrabsite/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>404 Not Found</title>
+</head>
+<body>
+<h1>404 Not Found</h1>
+<p>The page you requested was not found</p>
+</body>
+</html>

--- a/libgrabsite/dashboard.html
+++ b/libgrabsite/dashboard.html
@@ -1441,8 +1441,8 @@ var Dashboard = function() {
 	if(args["host"]) {
 		this.host = args["host"];
 	} else {
-		// Guess that the WebSocket port is one above the HTTP port
-		this.host = location.hostname + ':' + (Number(location.port) + 1);
+		// Guess that the WebSocket port is same as the HTTP port
+		this.host = location.hostname + ':' + Number(location.port);
 	}
 	this.dumpTraffic = args["dumpMax"] && Number(args["dumpMax"]) > 0;
 	if(this.dumpTraffic) {

--- a/libgrabsite/dashboard.html
+++ b/libgrabsite/dashboard.html
@@ -1438,11 +1438,11 @@ var Dashboard = function() {
 		JobsRenderer.prototype._renderDownloadLine = JobsRenderer.prototype._moreDomRenderDownloadLine;
 	}
 
+	// If no ?host=, connect to this server not some other server
 	if(args["host"]) {
 		this.host = args["host"];
 	} else {
-		// Guess that the WebSocket port is same as the HTTP port
-		this.host = location.hostname + ':' + Number(location.port);
+		this.host = location.host;
 	}
 	this.dumpTraffic = args["dumpMax"] && Number(args["dumpMax"]) > 0;
 	if(this.dumpTraffic) {

--- a/libgrabsite/server.py
+++ b/libgrabsite/server.py
@@ -63,7 +63,7 @@ class GrabberServerProtocol(WebSocketServerProtocol):
 					"pattern": obj["pattern"],
 				})
 
-	# Called when we get an HTTP request insttead of a WebSocket request
+	# Called when we get an HTTP request instead of a WebSocket request
 	def sendServerStatus(self, redirectUrl=None, redirectAfter=0):
 		requestPath = self.http_request_uri.split("?")[0]
 		if requestPath == "/":
@@ -71,14 +71,14 @@ class GrabberServerProtocol(WebSocketServerProtocol):
 				dashboardHtml = f.read()
 				self.sendHtml(dashboardHtml)
 		else:
-			send404()
+			self.send404()
 	
 	def send404(self):
 		with open(os.path.join(os.path.dirname(__file__), "404.html"), "r") as f:
 			responseHtml = f.read()
 		response = "HTTP/1.1 404 Not Found\x0d\x0a"
 		response += "Content-Type: text/html; charset=UTF-8\x0d\x0a"
-		response += "Content-Length: {}".format(len(responseHtml))
+		response += "Content-Length: {}\x0d\x0a".format(len(responseHtml))
 		response += "\x0d\x0a"
 		response += responseHtml
 		self.sendData(response.encode("utf_8"))

--- a/libgrabsite/wpull_hooks.py
+++ b/libgrabsite/wpull_hooks.py
@@ -79,8 +79,8 @@ class Decayer(object):
 
 @asyncio.coroutine
 def connect_to_server():
-	host = os.environ.get('GRAB_SITE_WS_HOST', '127.0.0.1')
-	port = int(os.environ.get('GRAB_SITE_WS_PORT', 29001))
+	host = os.environ.get('GRAB_SITE_HOST', '127.0.0.1')
+	port = int(os.environ.get('GRAB_SITE_PORT', 29000))
 	decayer = Decayer(0.25, 1.5, 8)
 	while True:
 		try:

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,6 @@ install_requires = [
 	"trollius>=2"
 ]
 
-# aiohttp 0.18.0 removed support for Python 3.4.0
-# https://github.com/KeepSafe/aiohttp/issues/676
-if sys.version_info[:3] < (3, 4, 1):
-	install_requires.append("aiohttp>=0.16.6,<0.18.0")
-else:
-	install_requires.append("aiohttp>=0.16.6")
-
 if 'GRAB_SITE_NO_CCHARDET' not in os.environ:
 	install_requires.append("cchardet>=0.3.5")
 


### PR DESCRIPTION
I've changed the gs-server and other requisite files so that it only uses a single port.  I think it might be easier on people not to have to juggle two.  Feel free to close this if this clashes with your own plans or you'd rather implement something in a different way.