### PR TITLE
googleplus igset: Ignore more login URLs

### DIFF
--- a/libgrabsite/ignore_sets/googleplus
+++ b/libgrabsite/ignore_sets/googleplus
@@ -1,3 +1,6 @@
+^https?://accounts\.google\.com/AccountChooser
+^https?://www\.google\.com/accounts/AccountChooser
+^https?://accounts\.google\.com/a/UniversalLogin
 ^https?://accounts\.google\.com/ServiceLogin
 ^https?://accounts\.google\.com/SignUp
 ^https?://lh4\.googleusercontent\.com/proxy/[^/]+


### PR DESCRIPTION
These URLs typically redirect to a '/ServiceLogin' URL, but it's good to
prevent the excess requests.

As a side note, I'm wondering if it would be a good ideal to rename the `googleplus` igset to some more general?  Or move parts of it into the `global` igset?  These changes were inspired by trying to grab a sites.google.com site.