### PR TITLE
Better alignment values for larger crawl

### DIFF
--- a/libgrabsite/dashboard.html
+++ b/libgrabsite/dashboard.html
@@ -136,7 +136,7 @@ html, body, .job-ident {
 }
 
 .job-responses-aligned {
-	width: 92px;
+	width: 120px;
 	overflow: hidden;
 	text-overflow: hidden;
 	text-align: right;
@@ -150,14 +150,14 @@ html, body, .job-ident {
 }
 
 .job-in-queue-aligned {
-	width: 92px;
+	width: 120px;
 	overflow: hidden;
 	text-overflow: hidden;
 	text-align: right;
 }
 
 .job-connections-aligned {
-	width: 14px;
+	width: 30px;
 	overflow: hidden;
 	text-overflow: hidden;
 	text-align: right;


### PR DESCRIPTION
When 'align' button is hit, this allows for more readable spacing in the alignment for larger crawls with millions of urls queued and 2-digit thread numbers, etc.